### PR TITLE
Configuration option to override style with a Glamour JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ mp.setup(
     {
       glow = {
         -- When find executable path of `glow` failed (from PATH), use this value instead
-        exec_path = ''
+        exec_path = '',
+        style = '', -- Path to glamour JSON style file
       },
       -- Markdown preview term
       term = {

--- a/lua/markdown-preview/config.lua
+++ b/lua/markdown-preview/config.lua
@@ -4,7 +4,8 @@
 local defaults = {
   glow = {
     -- When find executable path of `glow` failed (from PATH), use this value instead
-    exec_path = ''
+    exec_path = '',
+    style = '' -- Path to glamour JSON style file
   },
   -- Markdown preview term
   term = {
@@ -35,6 +36,18 @@ M.get_glow_exec = function()
     exec_path = 'glow'
   end
   return exec_path
+end
+
+---Get style
+---
+---@return string
+M.get_style = function()
+  local glow = M.opts.glow or {}
+  if string.len(glow['style']) > 0 then
+    return glow['style']
+  else
+    return vim.api.nvim_get_option('background') == 'light' and 'light' or 'dark'
+  end
 end
 
 ---Assign options

--- a/lua/markdown-preview/term.lua
+++ b/lua/markdown-preview/term.lua
@@ -182,8 +182,8 @@ function Term:render()
   self.tf = tf
 
   local glow_exec = config.get_glow_exec()
-  local background = api.nvim_get_option('background') == 'light' and 'light' or 'dark'
-  local cmd_args = {glow_exec, '-s', background, self.tf}
+  local style = config.get_style()
+  local cmd_args = {glow_exec, '-s', style, self.tf}
 
   self:unlock()
   local chan = api.nvim_open_term(vim.g.mp_bufnr, {})


### PR DESCRIPTION
This change allows for overriding the style parameter with a path to a JSON file from [glamour](https://github.com/charmbracelet/glamour/tree/master/styles).
If no style is provided it falls back to dark or light.

No style:
```lua
config = function()
  require('markdown-preview').setup {
    glow = { exec_path = '/usr/local/bin/glow' }
  }
end
```
![image](https://github.com/0x00-ketsu/markdown-preview.nvim/assets/1509051/93f33568-3a6d-4d84-8335-324c401d9a03)

Style overridden to json file ([catppuccin](https://github.com/catppuccin/glamour)):
```lua
config = function()
  require('markdown-preview').setup {
    glow = { exec_path = '/usr/local/bin/glow', style = '~/.config/nvim/glamour_macchiato.json' }
  }
end
```
![image](https://github.com/0x00-ketsu/markdown-preview.nvim/assets/1509051/2614407b-89de-4402-950a-1d7048c2f430)
